### PR TITLE
Setup PHP session when a valid SAML session has been found.

### DIFF
--- a/SimpleSamlAuth.class.php
+++ b/SimpleSamlAuth.class.php
@@ -227,6 +227,10 @@ class SimpleSamlAuth {
 			return true;
 		}
 
+		if ( session_id() == '' ) {
+			wfSetupSession();
+		}
+
 		if ( $wgSamlRequirement >= SAML_REQUIRED ) {
 			self::$as->requireAuth();
 		}


### PR DESCRIPTION
Without this change and with PHP's `session.auto_start` set to false, no PHP session is started after login over SAML. MediaWiki does that with the function `wfSetupSession` defined in `includes/GlobalFunctions.php` and called when the login form is executed in `includes/specials/SpecialUserlogin.php`.

I am not 100% sure, whether this is the right place to call `wfSetupSession`. I only did limited testing.