### PR TITLE
Remove composer autoloading of SimpleSamlAuth.php.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,6 @@
 	"homepage": "https://www.mediawiki.org/wiki/Extension:SimpleSamlAuth",
 	"type": "mediawiki-extension",
 	"license" : "LGPL-3.0+",
-	"autoload": {
-		"files": ["SimpleSamlAuth.php"]
-	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "0.5.0"
 	},


### PR DESCRIPTION
It took me a long time to realize and the documentation is still really bad, but I think the way to go is to use composer only for installing extensions and enabling them with a different means (currently `require $IP/extensions/SimpleSamleAuth/...`).

See also:
* https://phabricator.wikimedia.org/T467
* https://phabricator.wikimedia.org/rSVEC28c2e986ae5e5ac0fd43bde3d7a057b7c8771b77
* https://github.com/composer/composer/issues/4109