### PR TITLE
add a missing global declaration for $wgVersion

### DIFF
--- a/SimpleSamlAuth.class.php
+++ b/SimpleSamlAuth.class.php
@@ -451,6 +451,7 @@ class SimpleSamlAuth {
 		global $wgSamlUsernameAttr;
 		global $wgSamlMailAttr;
 		global $wgContLang;
+		global $wgVersion;
 
 		$changed = false;
 		if ( isset( $wgSamlRealnameAttr )


### PR DESCRIPTION
fix new user creation on mw 1.27.x and later; see issue #33