### PR TITLE
Use SimpleSAMLphp namespace to prevent syslog messages

### DIFF
--- a/SimpleSamlAuth.class.php
+++ b/SimpleSamlAuth.class.php
@@ -67,7 +67,7 @@ class SimpleSamlAuth {
 		require_once rtrim( $wgSamlSspRoot, DIRECTORY_SEPARATOR ) .
 			DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . '_autoload.php';
 
-		self::$as = new SimpleSAML_Auth_Simple( $wgSamlAuthSource );
+		self::$as = new SimpleSAML\Auth\Simple( $wgSamlAuthSource );
 
 		self::$initialised = is_object( self::$as );
 


### PR DESCRIPTION
Getting the following messages in `/var/log/messages`:

> Dec 18 03:49:33 <hostname> simplesamlphp[2523]: 4 [aece425b03] The class or interface 'SimpleSAML_Auth_Simple' is now using namespaces, please use 'SimpleSAML\Auth\Simple'.