### PR TITLE
Add $wgSamlGroupMapRegex to map groups via regex

### DIFF
--- a/SimpleSamlAuth.class.php
+++ b/SimpleSamlAuth.class.php
@@ -491,7 +491,19 @@ class SimpleSamlAuth {
 	}
 
 	/**
-	 * Add groups based on the existence of attributes in the SAML assertion.
+	 * Add groups based on two separate functions
+	 *
+	 * @param User $user add MediaWiki permissions to this user from the current SAML assertion
+	 *
+	 * @return void $user is modified on return
+	 */
+	protected static function setGroups( User $user ) {
+		self::setGroupsStandard( $user );
+		self::setGroupsRegex( $user );
+	}
+
+	/**
+	 * Add groups based on the existence of attributes with specific matches in the SAML assertion.
 	 *
 	 * @param User $user add MediaWiki permissions to this user from the current SAML assertion
 	 *
@@ -501,10 +513,12 @@ class SimpleSamlAuth {
 	 * $wgSamlGroupMap = [
 	 *     'mediawikigroup' => [
 	 *         'samlAttrName' => ['acceptable','saml','values'],
+	 *         '__ADDONLY__' => true
 	 *     ]
 	 * ]
+	 *
 	 */
-	protected static function setGroups( User $user ) {
+	protected static function setGroupsStandard ( User $user ) {
 		global $wgSamlGroupMap;
 
 		$allSamlAttrs = self::$as->getAttributes();
@@ -523,6 +537,8 @@ class SimpleSamlAuth {
 				// removed.
 				$intersections = array_intersect( $okValues, $allSamlAttrs[ $samlAttrName ] );
 
+				$onlyAdd = isset( $mediawikiGroup[ '__ADDONLY__' ] ) ? $mediawikiGroup[ '__ADDONLY__' ] : false;
+
 				if ( count( $intersections ) > 0 ) {
 					$user->addGroup( $mediawikiGroup );
 
@@ -530,7 +546,54 @@ class SimpleSamlAuth {
 					// proceed to the next mediawikiGroup
 					break;
 				}
-				else {
+				else if ( ! $onlyAdd ) {
+					$user->removeGroup( $mediawikiGroup );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Add groups based on regex matches to attributes in the SAML assertion.
+	 *
+	 * @param User $user add MediaWiki permissions to this user from the current SAML assertion
+	 *
+	 * @return void $user is modified on return
+	 *
+	 * @note $wgSamlGroupMapRegex is in the form:
+	 * $wgSamlGroupMapRegex = [
+	 *     'mediawikigroup' => [
+	 *         'samlAttrName' => "/SomeRegex/",
+	 *         '__ADDONLY__' => true
+	 *     ]
+	 * ]
+	 *
+	 */
+	protected static function setGroupsRegex ( User $user ) {
+		global $wgSamlGroupMapRegex;
+
+		$allSamlAttrs = self::$as->getAttributes();
+
+		foreach ( $wgSamlGroupMapRegex as $mediawikiGroup => $rules ) {
+			foreach ( $rules as $samlAttrName => $regex ) {
+				if ( ! isset( $allSamlAttrs[ $samlAttrName ] ) ) {
+					continue;
+				}
+
+				// A SAML attribute may have many values. Perform regex match
+				// against all of them and keep those that match.
+				$matchingValsFromAttr = preg_grep( $regex, $allSamlAttrs[ $samlAttrName ] );
+
+				$onlyAdd = isset( $mediawikiGroup[ '__ADDONLY__' ] ) ? $mediawikiGroup[ '__ADDONLY__' ] : false;
+
+				if ( count( $matchingValsFromAttr ) > 0 ) {
+					$user->addGroup( $mediawikiGroup );
+
+					// User allowed into group. Break out of this foreach and
+					// proceed to the next mediawikiGroup
+					break;
+				}
+				else if ( ! $onlyAdd ) {
 					$user->removeGroup( $mediawikiGroup );
 				}
 			}

--- a/SimpleSamlAuth.class.php
+++ b/SimpleSamlAuth.class.php
@@ -537,7 +537,12 @@ class SimpleSamlAuth {
 				// removed.
 				$intersections = array_intersect( $okValues, $allSamlAttrs[ $samlAttrName ] );
 
-				$onlyAdd = isset( $mediawikiGroup[ '__ADDONLY__' ] ) ? $mediawikiGroup[ '__ADDONLY__' ] : false;
+                                if ( isset( $wgSamlGroupMap[ $mediawikiGroup ][ '__ADDONLY__' ] ) ) {
+                                        $addOnly = $wgSamlGroupMap[ $mediawikiGroup ][ '__ADDONLY__' ];
+                                }
+                                else {
+                                        $addOnly = false;
+                                }
 
 				if ( count( $intersections ) > 0 ) {
 					$user->addGroup( $mediawikiGroup );
@@ -546,7 +551,7 @@ class SimpleSamlAuth {
 					// proceed to the next mediawikiGroup
 					break;
 				}
-				else if ( ! $onlyAdd ) {
+				else if ( ! $addOnly ) {
 					$user->removeGroup( $mediawikiGroup );
 				}
 			}
@@ -584,7 +589,12 @@ class SimpleSamlAuth {
 				// against all of them and keep those that match.
 				$matchingValsFromAttr = preg_grep( $regex, $allSamlAttrs[ $samlAttrName ] );
 
-				$onlyAdd = isset( $mediawikiGroup[ '__ADDONLY__' ] ) ? $mediawikiGroup[ '__ADDONLY__' ] : false;
+				if ( isset( $wgSamlGroupMapRegex[ $mediawikiGroup ][ '__ADDONLY__' ] ) ) {
+					$addOnly = $wgSamlGroupMapRegex[ $mediawikiGroup ][ '__ADDONLY__' ];
+				}
+				else {
+					$addOnly = false;
+				}
 
 				if ( count( $matchingValsFromAttr ) > 0 ) {
 					$user->addGroup( $mediawikiGroup );
@@ -593,7 +603,7 @@ class SimpleSamlAuth {
 					// proceed to the next mediawikiGroup
 					break;
 				}
-				else if ( ! $onlyAdd ) {
+				else if ( ! $addOnly ) {
 					$user->removeGroup( $mediawikiGroup );
 				}
 			}


### PR DESCRIPTION
Creates config variable `$wgSamlGroupMapRegex` which is identical in structure to `$wgSamlGroupMap` but matches groups via regex. 

```php
$wgSamlGroupMapRegex = [
	'mediawikiGroup' => [
		'samlAttrName' => "/SomeRegex/",
	],
];
```

I specifically created this to be able to match to attributes starting with a specific string, e.g. `"/^CX.*/"` being the attribute that starts with "CX" followed by any other characters.

Additionally, this PR adds the `__ADDONLY__` option, which makes it so SimpleSamlAuth will only add groups, but not remove them. To add this option, do:

```php
$wgSamlGroupMapRegex = [
	'mediawikiGroup' => [
		'samlAttrName' => "/SomeRegex/",
		'__ADDONLY__' => true
	],
];
```

This will mean that `mediawikiGroup` will be added to the user if `samlAttrName` matches `/SomeRegex/`, but it will not be removed if no match is found.